### PR TITLE
Private `timeout` Attribute

### DIFF
--- a/src/cnbc/api_wrapper.py
+++ b/src/cnbc/api_wrapper.py
@@ -23,7 +23,7 @@ class APIWrapper:
         self._endpoint: str
         self._params: dict[str, str]
         self._headers: dict[str, str]
-        self.timeout: int
+        self._timeout: int
 
         self._endpoint, self._params = endpoint.value
         self._headers = {'x-rapidapi-host': Endpoints.HOST.value, 'x-rapidapi-key': api_key}


### PR DESCRIPTION
### Overview
- The `timeout` attribute in the `APIWrapper` class was previous public, not private like the other attributes